### PR TITLE
Remove NetCapRaw logic

### DIFF
--- a/traceroute/structs.go
+++ b/traceroute/structs.go
@@ -33,7 +33,6 @@ type Opts struct {
 	Packet        []byte
 	TTL           int `json:"Ttl"`
 	Retries       int `json:"Retries"`
-	// NetCapRaw     bool `json:"NetCapRaw"`
 }
 
 // SysUnix is an interface for interacting with low-level system.
@@ -53,10 +52,12 @@ func (t task) GetId() uuid.UUID {
 	return t.Task.Id
 }
 
+// GetSensorId gets the id of the sensor, as received by the server
 func (t task) GetSensorId() uuid.UUID {
 	return t.Task.SensorId
 }
 
+// GetName gets the name of the task, as received by the server
 func (t task) GetName() sensor.TaskName {
 	return TaskName
 }
@@ -77,8 +78,8 @@ type Result struct {
 	Hops              []Hop
 }
 
-// SysUnixReal will be used for the real socket operation methods
-// should these methods be defined in structs.go?
+// SysUnixReal will be used for the actual socket operation
+// each method returns a call to "golang.org/x/sys/unix"
 type SysUnixReal struct{}
 
 func (s SysUnixReal) Socket(domain int, typ int, proto int) (fd int, err error) {

--- a/traceroute/traceroute.go
+++ b/traceroute/traceroute.go
@@ -38,6 +38,7 @@ func NewTaskFromBytes(msg []byte) (t task, err error) {
 		return
 	}
 
+	// assign the actual socket operation methods
 	t.SysUnix = &SysUnixReal{}
 
 	return t, nil
@@ -57,6 +58,7 @@ func NewTaskFromModel(t models.Task) (tRes task, err error) {
 		return
 	}
 
+	// assign the actual socket operation methods
 	tRes.SysUnix = &SysUnixReal{}
 
 	return tRes, nil
@@ -120,7 +122,7 @@ func (t *task) runHop() (hop Hop, err error) {
 			loggerTraceroute.Error("error parsing message", err)
 		}
 
-		// // do we need the header??
+		// TODO do we need the header??
 		// // parse the header
 		// parsedHeader, err := icmp.ParseIPv4Header(t.Packet)
 		// if err != nil {

--- a/traceroute/traceroute_test.go
+++ b/traceroute/traceroute_test.go
@@ -20,144 +20,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// func TestRunHop(t *testing.T) {
-// 	receivedMessage := []byte(`{"Id":"3b241101-e2bb-4255-8caf-4136c566a964","Name":"TRACEROUTE_TASK","SensorID":"3b241101-e2bb-4255-8caf-4136c566a964","Opts":{"Port":33434,"Dest":[8,8,8,8],"FirstHop":1,"MaxHops":30,"Timeout":5000,"PacketSize":52,"Retries":3}}`)
-
-// 	task, err := NewTaskFromBytes(receivedMessage)
-// 	if err != nil {
-// 		fmt.Println(err)
-// 		return
-// 	}
-// 	hop, err := task.runHop(context.TODO())
-// 	if err != nil {
-// 		fmt.Println(err)
-// 	}
-// 	loggerTraceroute.Infof("hop: %+v\n", hop)
-// 	assert.Nil(t, err)
-// 	assert.NotNil(t, hop)
-
-// }
-
-func TestTracerouteTaskMockedFromBytes(t *testing.T) {
-
-	mockSysUnix := &testingkit.MockedSysUnix{
-		SocketFunc: func(domain, typ, proto int) (int, error) {
-			return 1, nil
-		},
-		RecvfromFunc: func(fd int, p []byte, flags int) (int, unix.Sockaddr, error) {
-			// // mock getting package
-			return len(p), &unix.SockaddrInet4{}, nil
-		},
-	}
-
-	// mock message with default win payload
-	receivedMessage := []byte(`{"Id":"3b241101-e2bb-4255-8caf-4136c566a964","Name":"TRACEROUTE_TASK","SensorID":"3b241101-e2bb-4255-8caf-4136c566a964","Opts":{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}}`)
-
-	// Create an instance of the traceroute task with default options
-	tracerouteTask, err := NewTaskFromBytes(receivedMessage)
-	if err != nil {
-		fmt.Println("eror creating task:", err)
-	}
-
-	tracerouteTask.SysUnix = mockSysUnix
-	fmt.Printf("New TRACEROUTE Task: %v\n\n", tracerouteTask)
-
-	// Call the traceoute Run with test options from message
-	result, err := tracerouteTask.Run(context.TODO())
-
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Printf("unit test traceroute task results: %+v\n\n", string(result))
-
-	assert.Nil(t, err)
-	assert.NotNil(t, result)
-}
-
-func TestTracerouteTaskMockedFromModel(t *testing.T) {
-
-	mockSysUnix := &testingkit.MockedSysUnix{
-		SocketFunc: func(domain, typ, proto int) (int, error) {
-			return 1, nil
-		},
-		RecvfromFunc: func(fd int, p []byte, flags int) (int, unix.Sockaddr, error) {
-			// // mock getting package
-			return len(p), &unix.SockaddrInet4{}, nil
-		},
-	}
-	createdAt, err := time.Parse(time.RFC3339Nano, "2024-09-05T15:04:05.999999+00:00")
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	uuid := uuid.New()
-
-	// mock message with default win payload
-	lvTaskType := models.LvTaskType{
-		ID:   3,
-		Type: "TRACEROUTE",
-	}
-
-	lvTaskStatus := models.LvTaskStatus{
-		ID:     3,
-		Status: "pending",
-	}
-
-	org := models.Organization{
-		ID:   uuid,
-		Name: "ping",
-	}
-
-	sensor := models.Sensor{
-		ID:             uuid,
-		OrganizationID: uuid,
-		Organization:   org,
-		Name:           "pingSensor",
-		Location:       "TLV",
-		Secret:         "123",
-		IsActive:       true,
-		CreatedAt:      createdAt,
-	}
-
-	subscription := models.Subscription{}
-
-	modelTask := models.Task{
-		ID:             uuid,
-		TaskTypeID:     3,
-		TaskType:       lvTaskType,
-		TaskStatusID:   3,
-		TaskStatus:     lvTaskStatus,
-		SensorID:       uuid,
-		Sensor:         sensor,
-		SubscriptionID: 3,
-		Subscription:   subscription,
-		CreatedAt:      createdAt,
-		Opts:           []byte(`{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}`),
-	}
-
-	// Create an instance of the traceroute task with default options
-	tracerouteTask, err := NewTaskFromModel(modelTask)
-	if err != nil {
-		fmt.Println("eror creating task:", err)
-	}
-	tracerouteTask.SysUnix = mockSysUnix
-	fmt.Printf("New TRACEROUTE Task: %v\n\n", tracerouteTask)
-
-	// Call the traceoute Run with test options from message
-	result, err := tracerouteTask.Run(context.TODO())
-
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Printf("unit test traceroute task results: %+v\n\n", string(result))
-
-	assert.Nil(t, err)
-	assert.NotNil(t, result)
-}
-
 // this can be tested on root vscode
-func TestTracerouteTaskRealFromBytes(t *testing.T) {
+func TestTracerouteTaskFromBytes(t *testing.T) {
 
 	// mock message with default win payload
 	receivedMessage := []byte(`{"Id":"3b241101-e2bb-4255-8caf-4136c566a964","Name":"TRACEROUTE_TASK","SensorID":"3b241101-e2bb-4255-8caf-4136c566a964","Opts":{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}}`)
@@ -182,7 +46,7 @@ func TestTracerouteTaskRealFromBytes(t *testing.T) {
 }
 
 // this can be tested on root vscode
-func TestTracerouteTaskRealFromModel(t *testing.T) {
+func TestTracerouteTaskFromModel(t *testing.T) {
 
 	createdAt, err := time.Parse(time.RFC3339Nano, "2024-09-05T15:04:05.999999+00:00")
 	if err != nil {
@@ -254,3 +118,141 @@ func TestTracerouteTaskRealFromModel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, result)
 }
+
+// uses SysUnix interface's mocked methods
+func TestTracerouteTaskFromBytesMocked(t *testing.T) {
+
+	mockSysUnix := &testingkit.MockedSysUnix{
+		SocketFunc: func(domain, typ, proto int) (int, error) {
+			return 1, nil
+		},
+		RecvfromFunc: func(fd int, p []byte, flags int) (int, unix.Sockaddr, error) {
+			// // mock getting package
+			return len(p), &unix.SockaddrInet4{}, nil
+		},
+	}
+
+	// mock message with default win payload
+	receivedMessage := []byte(`{"Id":"3b241101-e2bb-4255-8caf-4136c566a964","Name":"TRACEROUTE_TASK","SensorID":"3b241101-e2bb-4255-8caf-4136c566a964","Opts":{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}}`)
+
+	// Create an instance of the traceroute task with default options
+	tracerouteTask, err := NewTaskFromBytes(receivedMessage)
+	if err != nil {
+		fmt.Println("eror creating task:", err)
+	}
+
+	tracerouteTask.SysUnix = mockSysUnix
+	fmt.Printf("New TRACEROUTE Task: %v\n\n", tracerouteTask)
+
+	// Call the traceoute Run with test options from message
+	result, err := tracerouteTask.Run(context.TODO())
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("unit test traceroute task results: %+v\n\n", string(result))
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+}
+
+// uses SysUnix interface's mocked methods
+func TestTracerouteTaskFromModelMocked(t *testing.T) {
+
+	mockSysUnix := &testingkit.MockedSysUnix{
+		SocketFunc: func(domain, typ, proto int) (int, error) {
+			return 1, nil
+		},
+		RecvfromFunc: func(fd int, p []byte, flags int) (int, unix.Sockaddr, error) {
+			// // mock getting package
+			return len(p), &unix.SockaddrInet4{}, nil
+		},
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, "2024-09-05T15:04:05.999999+00:00")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	uuid := uuid.New()
+
+	// mock message with default win payload
+	lvTaskType := models.LvTaskType{
+		ID:   3,
+		Type: "TRACEROUTE",
+	}
+
+	lvTaskStatus := models.LvTaskStatus{
+		ID:     3,
+		Status: "pending",
+	}
+
+	org := models.Organization{
+		ID:   uuid,
+		Name: "ping",
+	}
+
+	sensor := models.Sensor{
+		ID:             uuid,
+		OrganizationID: uuid,
+		Organization:   org,
+		Name:           "pingSensor",
+		Location:       "TLV",
+		Secret:         "123",
+		IsActive:       true,
+		CreatedAt:      createdAt,
+	}
+
+	subscription := models.Subscription{}
+
+	modelTask := models.Task{
+		ID:             uuid,
+		TaskTypeID:     3,
+		TaskType:       lvTaskType,
+		TaskStatusID:   3,
+		TaskStatus:     lvTaskStatus,
+		SensorID:       uuid,
+		Sensor:         sensor,
+		SubscriptionID: 3,
+		Subscription:   subscription,
+		CreatedAt:      createdAt,
+		Opts:           []byte(`{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}`),
+	}
+
+	// Create an instance of the traceroute task with default options
+	tracerouteTask, err := NewTaskFromModel(modelTask)
+	if err != nil {
+		fmt.Println("eror creating task:", err)
+	}
+	tracerouteTask.SysUnix = mockSysUnix
+	fmt.Printf("New TRACEROUTE Task: %v\n\n", tracerouteTask)
+
+	// Call the traceoute Run with test options from message
+	result, err := tracerouteTask.Run(context.TODO())
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("unit test traceroute task results: %+v\n\n", string(result))
+
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+}
+
+// func TestRunHop(t *testing.T) {
+// 	receivedMessage := []byte(`{"Id":"3b241101-e2bb-4255-8caf-4136c566a964","Name":"TRACEROUTE_TASK","SensorID":"3b241101-e2bb-4255-8caf-4136c566a964","Opts":{"Port":33434,"Dest":"8.8.8.8","FirstHop":1,"MaxHops":64,"Timeout":500,"PacketSize":52,"Retries":3}}`)
+
+// 	task, err := NewTaskFromBytes(receivedMessage)
+// 	if err != nil {
+// 		fmt.Println(err)
+// 		return
+// 	}
+// 	hop, err := task.runHop()
+// 	if err != nil {
+// 		fmt.Println(err)
+// 	}
+// 	loggerTraceroute.Infof("hop: %+v\n", hop)
+// 	assert.Nil(t, err)
+// 	assert.NotNil(t, hop)
+
+// }


### PR DESCRIPTION
## Changes Summary
WIP
The Sensor should now report on the container's capabilities, which indicate among other things whether or not it can perform a traceroute on raw sockets.
For this reason  `opts.NetCapRaw`  can  be removed. 
Note: The SysUnix interface's mocked methods can still be found in `/testingkit` and can be used for testing.
## Checklist:

- [ ] Tested locally with docker (linux AMD64 Go image) 
- [ ] Changes are reflected in the documentation
- [ ] Unit tests are in place, location: (list)
- [ ] New 3rd party dependencies: (list)

## Deployment Notes and Dependencies

*Deployment specifics & service-array a bump hint*
